### PR TITLE
Integrate phylo uncertainty by default in coev_plot_predictive_check()

### DIFF
--- a/man/coev_plot_predictive_check.Rd
+++ b/man/coev_plot_predictive_check.Rd
@@ -8,7 +8,7 @@ coev_plot_predictive_check(
   object,
   variables = NULL,
   ndraws = NULL,
-  tree_id = 1L
+  tree_id = NULL
 )
 }
 \arguments{
@@ -22,7 +22,7 @@ declaring the variables to be included in the list of plots.}
 default and maximum number of draws is the size of the posterior sample.}
 
 \item{tree_id}{An integer indicating the tree ID to use when making
-posterior predictions. Set to 1 by default.}
+posterior predictions. Set to \code{NULL} by default, which will use draws from every tree, integrating phylogenetic uncertainty.}
 }
 \value{
 A list of \code{ggplot} objects

--- a/man/coev_plot_predictive_check.Rd
+++ b/man/coev_plot_predictive_check.Rd
@@ -22,7 +22,8 @@ declaring the variables to be included in the list of plots.}
 default and maximum number of draws is the size of the posterior sample.}
 
 \item{tree_id}{An integer indicating the tree ID to use when making
-posterior predictions. Set to \code{NULL} by default, which will use draws from every tree, integrating phylogenetic uncertainty.}
+posterior predictions. Set to \code{NULL} by default, which will use draws
+from every tree, integrating phylogenetic uncertainty.}
 }
 \value{
 A list of \code{ggplot} objects

--- a/tests/testthat/test-coev_plot_predictive_check.R
+++ b/tests/testthat/test-coev_plot_predictive_check.R
@@ -51,6 +51,13 @@ test_that("coev_plot_predictive_check() produces expected errors and output", {
       ),
     "Argument 'ndraws' must be between 1 and the total number of draws."
   )
+  expect_error(
+    coev_plot_predictive_check(object = m1, tree_id = "fail"),
+    paste0(
+      "Argument 'tree_id' must be either NULL or a single positive ",
+      "integer less than the total number of trees."
+    )
+  )
   # suppress warnings
   SW <- suppressWarnings
   # should run without error and produce list of ggplot objects


### PR DESCRIPTION
The function now uses all trees to plot predictive checks by default. Internally, it simply loops over the trees and rbinds the draws into a matrix.