### PR TITLE
Fix nutpie/JAX backend: yrep, log_lik, prior_only, and missing-data generated quantities

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: coevolve
 Title: Fit Bayesian Generalized Dynamic Phylogenetic Models using 'Stan' or 'JAX'
-Version: 1.2.0
+Version: 1.2.0.9000
 Authors@R: 
     c(person("Scott", "Claessens", , "scott.claessens@gmail.com", 
              role = c("aut", "cre"), comment = c(ORCID = "0000-0002-3562-6981")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,23 @@
+# coevolve - development version
+
+### Bug Fixes
+
+* Fixed `coev_plot_predictive_check()` when `nuts_sampler = "nutpie"`. The
+  JAX backend now returns `yrep` posterior predictions alongside the other
+  model parameters, matching the Stan backend (#118)
+* `log_lik = TRUE` is now supported with `nuts_sampler = "nutpie"`. The JAX
+  backend previously ignored the argument and returned no `log_lik`, so
+  `loo` and `waic` could not be computed from nutpie fits (#118)
+* Fixed `prior_only = TRUE` for models with gaussian variables and no
+  repeated observations. `terminal_drift` only received a prior inside the
+  likelihood block, leaving it improper when the likelihood was skipped.
+  Sampling failed to initialise with `nuts_sampler = "nutpie"` and was
+  unreliable with `nuts_sampler = "stan"` (#118)
+* Fixed the pointwise `log_lik` and `yrep` for gaussian variables with
+  missing data. The generated quantities block used the `-9999` missing
+  value placeholder when constructing residuals, which corrupted the
+  conditional densities of the other variables of the same observation
+
 # coevolve 1.2.0
 
 ### New Features

--- a/R/coev_fit.R
+++ b/R/coev_fit.R
@@ -307,7 +307,7 @@ coev_fit <- function(data, variables, id, tree,
       complete_cases, lon_lat, dist_k, dist_cov,
       measurement_error, prior, scale,
       estimate_correlated_drift, estimate_residual,
-      prior_only
+      log_lik, prior_only
     )
   } else {
     sc <- coev_make_stancode(data, variables, id, tree, effects_mat,

--- a/R/coev_make_model_config.R
+++ b/R/coev_make_model_config.R
@@ -13,12 +13,13 @@ coev_make_model_config <- function(data, variables, id, tree,
                                    prior = NULL, scale = TRUE,
                                    estimate_correlated_drift = TRUE,
                                    estimate_residual = TRUE,
+                                   log_lik = FALSE,
                                    prior_only = FALSE) {
 
   run_checks(data, variables, id, tree, effects_mat, complete_cases, lon_lat,
              dist_k, dist_cov, measurement_error, prior, scale,
              estimate_correlated_drift, estimate_residual,
-             log_lik = FALSE, prior_only = prior_only)
+             log_lik = log_lik, prior_only = prior_only)
 
   data <- as.data.frame(data)
   distributions <- as.character(variables)
@@ -85,6 +86,7 @@ coev_make_model_config <- function(data, variables, id, tree,
 
   list(
     distributions           = distributions,
+    log_lik                 = as.integer(log_lik),
     tdrift                  = as.integer(tdrift),
     repeated                = as.integer(repeated),
     needs_terminal_drift    = as.integer(needs_terminal_drift),

--- a/R/coev_make_stancode.R
+++ b/R/coev_make_stancode.R
@@ -277,7 +277,7 @@ coev_make_stancode <- function(data, variables, id, tree,
     "\n\n",
     write_model_block(data, distributions, id, lon_lat, priors,
                       measurement_error, estimate_correlated_drift,
-                      estimate_residual),
+                      estimate_residual, prior_only),
     "\n\n",
     write_gen_quantities_block(data, distributions, id, lon_lat,
                                measurement_error, estimate_correlated_drift,
@@ -580,15 +580,18 @@ write_transformed_pars_block <- function(data, distributions, id, lon_lat,
 #' @noRd
 write_model_block <- function(data, distributions, id, lon_lat, priors,
                               measurement_error, estimate_correlated_drift,
-                              estimate_residual) {
+                              estimate_residual, prior_only = FALSE) {
   # check for repeated
   repeated <- any(duplicated(data[, id])) && estimate_residual
   # add priors for terminal_drift when:
   # 1. there are no repeated measures and no gaussian variables  OR
-  # 2. there are repeated measures and estimate_residual = TRUE
+  # 2. there are repeated measures and estimate_residual = TRUE  OR
+  # 3. the likelihood is skipped, since terminal_drift would otherwise be
+  #    left without any prior at all (its std_normal prior for gaussian
+  #    variables is declared inside the likelihood block)
   add_terminal_drift_prior <-
     (!any(duplicated(data[, id])) && !("normal" %in% distributions)) ||
-    (repeated)
+    (repeated) || prior_only
   # which variables are ordinal?
   ordered_seq <- FALSE
   if ("ordered_logistic" %in% distributions) {

--- a/inst/python/coev_jax_model.py
+++ b/inst/python/coev_jax_model.py
@@ -6,6 +6,8 @@ using numpyro.distributions for distribution log-probs. No PyMC or PyTensor.
 Designed to be called via nutpie.compiled_pyfunc.from_pyfunc().
 """
 
+import itertools
+
 import jax
 import jax.numpy as jnp
 import jax.scipy.linalg
@@ -308,6 +310,7 @@ class CoevJaxModel:
         self.effects_mat = np.asarray(data["effects_mat"], dtype=np.int32)
         self.n_offdiag = int(data["n_offdiag"])
         self.prior_only = bool(int(data["prior_only"]))
+        self.log_lik = bool(int(data["log_lik"]))
 
         self.tdrift = bool(int(data["tdrift"]))
         self.repeated = bool(int(data["repeated"]))
@@ -361,6 +364,15 @@ class CoevJaxModel:
 
         if self.has_measurement_error:
             self.se = jnp.array(data["se"], dtype=jnp.float64)
+            # `se` is indexed by observation; posterior predictions need it
+            # indexed by tip, because replicated terminal drift is drawn once
+            # per tip (cf. Stan 07-generated-quantities.stan).
+            if not self.repeated:
+                se_by_tip = np.zeros((self.N_tips, self.J))
+                se_by_tip[self.tip_id] = np.asarray(
+                    data["se"], dtype=np.float64
+                )
+                self.se_by_tip = jnp.array(se_by_tip)
 
         # Tree traversal level data
         self.n_levels = int(data["n_levels"])
@@ -521,6 +533,9 @@ class CoevJaxModel:
         if self.repeated:
             vs.append(("sigma_residual", (J,)))
             vs.append(("cor_residual", (J, J)))
+        vs.append(("yrep", (self.N_tree, self.N_obs, J)))
+        if self.log_lik:
+            vs.append(("log_lik", (self.N_obs * J,)))
         return vs
 
     def _build_expand_info(self):
@@ -827,17 +842,18 @@ class CoevJaxModel:
         lp = lp + dist.Normal(0.0, 1.0).log_prob(params["z_drift"]).sum()
 
         # terminal_drift prior — match Stan exactly:
-        #   add_terminal_drift_prior (= self.tdrift): global std_normal
-        #   set_tdrift (= !self.tdrift): inline per-obs prior on normal
-        #     columns (only when likelihood is evaluated, i.e. !prior_only)
-        if self.tdrift:
+        #   add_terminal_drift_prior (= self.tdrift or prior_only): global
+        #     std_normal. Under prior_only the inline prior below is never
+        #     reached, so terminal_drift would otherwise be left improper.
+        #   set_tdrift: inline per-obs prior on normal columns
+        if self.tdrift or self.prior_only:
             # Stan: to_vector(terminal_drift[t]) ~ std_normal();
             lp = lp + (
                 dist.Normal(0.0, 1.0)
                 .log_prob(params["terminal_drift"])
                 .sum()
             )
-        elif not self.prior_only:
+        else:
             # Stan set_tdrift block: for observed normal vars,
             #   terminal_drift[t][tip_id[i],j] ~ std_normal()
             # For non-normal vars: no separate prior (enters via MVN)
@@ -1110,6 +1126,221 @@ class CoevJaxModel:
         return jnp.sum(jax.scipy.special.logsumexp(all_tree_lps, axis=0))
 
     # ------------------------------------------------------------------
+    # Pointwise log-likelihood  (cf. Stan 07-generated-quantities.stan)
+    # ------------------------------------------------------------------
+
+    def _generate_log_lik(self, params, eta, tip_L_VCV, tdrift, residual_v,
+                          L_residual, dist_v):
+        """Log-likelihood of every (observation, variable) cell.
+
+        Mirrors Stan 07-generated-quantities.stan. Normal variables
+        contribute the *conditional* univariate density given the other
+        variables of the same observation, so that each cell can be scored
+        separately; other variables contribute their own lpmf/lpdf. Missing
+        cells contribute zero before trees are combined with log_sum_exp.
+
+        Returns an (N_obs * J,) vector flattened column-major to match
+        Stan's `to_vector()` of an (N_obs, J) matrix.
+        """
+        J = self.J
+        tid = self.tip_id
+        has_normal = "normal" in self.distributions
+
+        def _one_tree(eta_t, tip_L_VCV_t, tdrift_t, terminal_drift_t):
+            def base_lmod(j0):
+                lm = eta_t[tid][:, j0]
+                if dist_v is not None:
+                    lm = lm + dist_v[tid, j0]
+                return lm
+
+            # `vec` collects the quantity that is multivariate normal across
+            # variables: residuals when observations repeat, terminal drift
+            # otherwise (cf. the Stan set_residuals / set_tdrifts blocks).
+            # Observed normal cells are pinned to the data; every other cell
+            # keeps its latent value.
+            if not has_normal:
+                vec = residual_v if self.repeated else tdrift_t[tid]
+            elif self.repeated:
+                vec = params["residual_z"].T
+                for j0 in self.normal_j0:
+                    vec = vec.at[:, j0].set(
+                        jnp.where(
+                            self.miss[:, j0] == 0,
+                            self.y[:, j0]
+                            - (base_lmod(j0) + tdrift_t[tid][:, j0]),
+                            params["residual_z"][j0],
+                        )
+                    )
+            else:
+                vec = terminal_drift_t[tid]
+                for j0 in self.normal_j0:
+                    vec = vec.at[:, j0].set(
+                        jnp.where(
+                            self.miss[:, j0] == 0,
+                            self.y[:, j0] - base_lmod(j0),
+                            terminal_drift_t[tid][:, j0],
+                        )
+                    )
+
+            # Conditional mean and sd of each normal variable given the
+            # others, from the precision matrix of `vec`.
+            mu_cond = None
+            sigma_cond = None
+            if has_normal:
+                if self.repeated:
+                    L_cov = jnp.diag(params["sigma_residual"]) @ L_residual
+                    cov = jnp.broadcast_to(
+                        L_cov @ L_cov.T, (self.N_obs, J, J)
+                    )
+                else:
+                    L_cov = tip_L_VCV_t[tid]
+                    cov = jnp.matmul(L_cov, L_cov.transpose(0, 2, 1))
+                if self.has_measurement_error:
+                    cov = cov + (
+                        self.se[:, :, None] * jnp.eye(J)[None, :, :]
+                    )
+                cov_inv = jnp.linalg.inv(cov)
+                prec_diag = jnp.diagonal(cov_inv, axis1=-2, axis2=-1)
+                mu_cond = vec - (
+                    jnp.einsum("ijk,ik->ij", cov_inv, vec) / prec_diag
+                )
+                sigma_cond = jnp.sqrt(1.0 / prec_diag)
+
+            cols = []
+            for j0, d in enumerate(self.distributions):
+                if d == "normal":
+                    cols.append(
+                        dist.Normal(
+                            mu_cond[:, j0], sigma_cond[:, j0]
+                        ).log_prob(vec[:, j0])
+                    )
+                    continue
+
+                lmod = base_lmod(j0) + vec[:, j0]
+                miss_j = self.miss[:, j0] == 1
+                y_obs = self.y[:, j0]
+                j1 = j0 + 1
+
+                if d == "bernoulli_logit":
+                    y_safe = jnp.where(miss_j, 0.0, y_obs)
+                    ll = dist.Bernoulli(logits=lmod).log_prob(y_safe)
+                elif d == "ordered_logistic":
+                    y_safe = jnp.where(miss_j, 1.0, y_obs)
+                    ll = _ordered_logistic_logp(
+                        lmod, params[f"c{j1}"], (y_safe - 1).astype(jnp.int32)
+                    )
+                elif d == "poisson_softplus":
+                    y_safe = jnp.where(miss_j, 0.0, y_obs)
+                    ll = dist.Poisson(
+                        rate=self.obs_means[j0] * jax.nn.softplus(lmod)
+                    ).log_prob(y_safe.astype(jnp.int32))
+                elif d == "negative_binomial_softplus":
+                    y_safe = jnp.where(miss_j, 0.0, y_obs)
+                    ll = dist.NegativeBinomial2(
+                        mean=self.obs_means[j0] * jax.nn.softplus(lmod),
+                        concentration=params[f"phi{j1}"].squeeze(),
+                    ).log_prob(y_safe.astype(jnp.int32))
+                elif d == "gamma_log":
+                    y_safe = jnp.where(miss_j, 1.0, y_obs)
+                    alpha = params[f"shape{j1}"].squeeze()
+                    ll = dist.Gamma(
+                        concentration=alpha, rate=alpha / jnp.exp(lmod)
+                    ).log_prob(y_safe)
+                else:
+                    raise ValueError(f"Unsupported distribution: {d!r}")
+                cols.append(ll)
+
+            return jnp.where(self.miss == 0, jnp.stack(cols, axis=-1), 0.0)
+
+        tdrift_batched = (
+            tdrift
+            if tdrift is not None
+            else jnp.zeros((self.N_tree, self.N_tips, J))
+        )
+        all_tree_lps = jax.vmap(_one_tree, in_axes=(0, 0, 0, 0))(
+            eta, tip_L_VCV, tdrift_batched, params["terminal_drift"]
+        )
+        # Combine trees, then flatten column-major like Stan's to_vector().
+        return jax.scipy.special.logsumexp(all_tree_lps, axis=0).T.reshape(-1)
+
+    # ------------------------------------------------------------------
+    # Posterior predictions  (cf. Stan 07-generated-quantities.stan)
+    # ------------------------------------------------------------------
+
+    def _generate_yrep(self, params, eta, tip_L_VCV, dist_v, L_residual, key):
+        """Draw posterior predictions for every observation and tree.
+
+        Mirrors Stan 07-generated-quantities.stan: replicated terminal drift
+        is drawn once per tip (shared by repeated observations of that tip),
+        replicated residuals once per observation, and each variable is then
+        drawn from its response distribution.
+
+        Returns an (N_tree, N_obs, J) array.
+        """
+        J = self.J
+        tid = self.tip_id
+        key_drift, key_resid, key_obs = jax.random.split(key, 3)
+
+        # terminal_drift_rep[t,i] = cholesky_decompose(VCV_tips[t,i]) * z
+        L_tip = tip_L_VCV
+        if self.has_measurement_error and not self.repeated:
+            VCV_tip = jnp.matmul(L_tip, L_tip.transpose(0, 1, 3, 2))
+            se_diag = (
+                self.se_by_tip[:, :, None] * jnp.eye(J)[None, :, :]
+            )
+            L_tip = jnp.linalg.cholesky(VCV_tip + se_diag[None, :, :, :])
+        drift_rep = jnp.einsum(
+            "tijk,tik->tij",
+            L_tip,
+            jax.random.normal(key_drift, (self.N_tree, self.N_tips, J)),
+        )
+
+        lmod = eta[:, tid, :] + drift_rep[:, tid, :]
+        if dist_v is not None:
+            lmod = lmod + dist_v[tid][None, :, :]
+        if self.repeated:
+            lmod = lmod + jnp.einsum(
+                "jk,tik->tij",
+                jnp.diag(params["sigma_residual"]) @ L_residual,
+                jax.random.normal(
+                    key_resid, (self.N_tree, self.N_obs, J)
+                ),
+            )
+
+        keys_j = jax.random.split(key_obs, len(self.distributions))
+        cols = []
+        for j0, d in enumerate(self.distributions):
+            lm = lmod[:, :, j0]
+            key_j = keys_j[j0]
+            if d == "normal":
+                draw = lm
+            elif d == "bernoulli_logit":
+                draw = dist.Bernoulli(logits=lm).sample(key_j)
+            elif d == "ordered_logistic":
+                draw = 1 + dist.OrderedLogistic(
+                    lm, params[f"c{j0 + 1}"]
+                ).sample(key_j)
+            elif d == "poisson_softplus":
+                draw = dist.Poisson(
+                    rate=self.obs_means[j0] * jax.nn.softplus(lm)
+                ).sample(key_j)
+            elif d == "negative_binomial_softplus":
+                draw = dist.NegativeBinomial2(
+                    mean=self.obs_means[j0] * jax.nn.softplus(lm),
+                    concentration=params[f"phi{j0 + 1}"].squeeze(),
+                ).sample(key_j)
+            elif d == "gamma_log":
+                alpha = params[f"shape{j0 + 1}"].squeeze()
+                draw = dist.Gamma(
+                    concentration=alpha, rate=alpha / jnp.exp(lm)
+                ).sample(key_j)
+            else:
+                raise ValueError(f"Unsupported distribution: {d!r}")
+            cols.append(draw.astype(jnp.float64))
+
+        return jnp.stack(cols, axis=-1)
+
+    # ------------------------------------------------------------------
     # Main log-density  (orchestrates all blocks)
     # ------------------------------------------------------------------
 
@@ -1185,13 +1416,16 @@ class CoevJaxModel:
         Keys are returned in the exact order of _expand_var_list().
         The JAX computation is JIT-compiled; only the final
         jax->numpy conversion runs in Python.
+
+        `yrep` needs randomness, so each call folds a per-draw counter into
+        a chain-specific PRNG key seeded from nutpie's (seed1, seed2, chain).
         """
         J = self.J
         var_order = [n for n, _ in self._expand_var_list()]
 
         # JIT-compile the pure JAX part
         @jax.jit
-        def _expand_jax(x):
+        def _expand_jax(x, key):
             params, _ = self.unpack_params(x)
             vals = []
 
@@ -1212,6 +1446,16 @@ class CoevJaxModel:
                 L_VCV_cache,
                 b_delta_cache,
             )
+
+            L_residual = None
+            if self.repeated:
+                n_corr_res = J * (J - 1) // 2
+                if n_corr_res > 0:
+                    L_residual, _ = raw_to_cholesky(
+                        params["_L_residual_raw"], J
+                    )
+                else:
+                    L_residual = jnp.eye(J)
 
             vals.append(params["A_diag"])
             if self.n_offdiag > 0:
@@ -1239,23 +1483,46 @@ class CoevJaxModel:
 
             if self.repeated:
                 vals.append(params["sigma_residual"])
-                n_corr_res = J * (J - 1) // 2
-                if n_corr_res > 0:
-                    L_res, _ = raw_to_cholesky(
-                        params["_L_residual_raw"], J
+                vals.append(L_residual @ L_residual.T)  # cor_residual
+
+            # Generated quantities. Unused transformed parameters are
+            # eliminated by XLA, so nothing here is computed twice.
+            tdrift, residual_v, dist_v = self._transformed_params(
+                params, tip_L_VCV, L_residual
+            )
+            vals.append(
+                self._generate_yrep(
+                    params, eta, tip_L_VCV, dist_v, L_residual, key
+                )
+            )
+            if self.log_lik:
+                vals.append(
+                    self._generate_log_lik(
+                        params, eta, tip_L_VCV, tdrift, residual_v,
+                        L_residual, dist_v
                     )
-                else:
-                    L_res = jnp.eye(J)
-                vals.append(L_res @ L_res.T)  # cor_residual
+                )
 
             return vals
 
         # Warm up JIT
         _x0 = jnp.zeros(self.ndim)
-        _expand_jax(_x0)
+        _expand_jax(_x0, jax.random.PRNGKey(0))
+
+        # Chain-specific base key; each draw folds in its own counter so that
+        # yrep uses a fresh, reproducible random stream.
+        base_key = jax.random.fold_in(
+            jax.random.PRNGKey(int(seed1) % (2 ** 32)),
+            int(seed2) % (2 ** 31),
+        )
+        base_key = jax.random.fold_in(base_key, int(chain))
+        draw_counter = itertools.count()
 
         def expand(x):
-            jax_vals = _expand_jax(jnp.asarray(x))
+            jax_vals = _expand_jax(
+                jnp.asarray(x),
+                jax.random.fold_in(base_key, next(draw_counter)),
+            )
             result = {}
             for i, name in enumerate(var_order):
                 result[name] = np.asarray(

--- a/inst/stan/templates/07-generated-quantities.stan
+++ b/inst/stan/templates/07-generated-quantities.stan
@@ -45,7 +45,11 @@ generated quantities{
         {{/repeated}}
         {{#set_residuals}}
         {{#is_normal}}
-        residuals[{{j}}] = y[i][{{j}}] - ({{lmod}} + tdrift[t,tip_id[i]][{{j}}]);
+        if (miss[i,{{j}}] == 0) {
+          residuals[{{j}}] = y[i,{{j}}] - ({{lmod}} + tdrift[t,tip_id[i]][{{j}}]);
+        } else {
+          residuals[{{j}}] = residual_z[{{j}},i];
+        }
         {{/is_normal}}
         {{#is_not_normal_and_normal_present}}
         residuals[{{j}}] = residual_z[{{j}},i];
@@ -56,7 +60,11 @@ generated quantities{
         {{/set_residuals}}
         {{#set_tdrifts}}
         {{#is_normal}}
-        tdrifts[{{j}}] = y[i][{{j}}] - ({{lmod}});
+        if (miss[i,{{j}}] == 0) {
+          tdrifts[{{j}}] = y[i,{{j}}] - ({{lmod}});
+        } else {
+          tdrifts[{{j}}] = terminal_drift[t][tip_id[i],{{j}}];
+        }
         {{/is_normal}}
         {{#is_not_normal_and_normal_present}}
         tdrifts[{{j}}] = terminal_drift[t,tip_id[i]][{{j}}];

--- a/tests/testthat/test-coev_fit_nutpie.R
+++ b/tests/testthat/test-coev_fit_nutpie.R
@@ -438,6 +438,204 @@ test_that("Plotting functions work with JAX fit", {
   )
 })
 
+test_that("JAX fit generates yrep posterior predictions", {
+  skip_if_not(
+    coevolve:::check_jax_available(),
+    message = "JAX not available - skipping JAX tests"
+  )
+  fit_args <- list(
+    data = authority$data,
+    variables = list(
+      political_authority = "ordered_logistic",
+      religious_authority = "ordered_logistic"
+    ),
+    id = "language",
+    tree = authority$phylogeny,
+    prior = list(A_offdiag = "normal(0, 2)"),
+    nuts_sampler = "nutpie",
+    chains = 2,
+    iter_warmup = 100,
+    iter_sampling = 100,
+    seed = 1
+  )
+  fit <- do.call(coev_fit, fit_args)
+  sd <- fit$stan_data
+  # yrep is returned with the same dimensions as the Stan backend
+  yrep <- posterior::draws_of(
+    posterior::as_draws_rvars(fit$fit$draws(variables = "yrep"))$yrep
+  )
+  expect_equal(
+    dim(yrep), c(fit$nsamples, sd$N_tree, sd$N_obs, sd$J)
+  )
+  # ordinal predictions fall within the observed category range
+  expect_true(all(yrep == round(yrep)))
+  expect_true(all(yrep >= 1 & yrep <= max(sd$y)))
+  # predictions vary across draws and across chains
+  expect_gt(stats::sd(yrep[, 1, 1, 1]), 0)
+  draws_arr <- fit$fit$draws(variables = "yrep")
+  expect_false(
+    identical(as.vector(draws_arr[1, 1, ]), as.vector(draws_arr[1, 2, ]))
+  )
+  # predictive checks now work for nutpie fits (#118)
+  sw <- suppressWarnings
+  expect_no_error(pp <- sw(coev_plot_predictive_check(fit)))
+  expect_named(pp, names(fit$variables))
+  expect_no_error(sw(coev_plot_predictive_check(fit, ndraws = 1)))
+  # same seed reproduces the same predictions
+  expect_equal(
+    posterior::draws_of(
+      posterior::as_draws_rvars(
+        do.call(coev_fit, fit_args)$fit$draws(variables = "yrep")
+      )$yrep
+    ),
+    yrep
+  )
+})
+
+test_that("JAX yrep works with repeated observations and normal variables", {
+  skip_if_not(
+    coevolve:::check_jax_available(),
+    message = "JAX not available - skipping JAX tests"
+  )
+  fit <- coev_fit(
+    data = repeated$data,
+    variables = list(
+      x = "normal",
+      y = "normal"
+    ),
+    id = "species",
+    tree = repeated$phylogeny,
+    nuts_sampler = "nutpie",
+    chains = 1,
+    iter_warmup = 100,
+    iter_sampling = 100,
+    seed = 1
+  )
+  sd <- fit$stan_data
+  yrep <- posterior::draws_of(
+    posterior::as_draws_rvars(fit$fit$draws(variables = "yrep"))$yrep
+  )
+  expect_equal(
+    dim(yrep), c(fit$nsamples, sd$N_tree, sd$N_obs, sd$J)
+  )
+  expect_true(all(is.finite(yrep)))
+  expect_no_error(suppressWarnings(coev_plot_predictive_check(fit)))
+})
+
+test_that("JAX fit returns log_lik when log_lik = TRUE", {
+  skip_if_not(
+    coevolve:::check_jax_available(),
+    message = "JAX not available - skipping JAX tests"
+  )
+  fit_args <- list(
+    data = authority$data,
+    variables = list(
+      political_authority = "ordered_logistic",
+      religious_authority = "ordered_logistic"
+    ),
+    id = "language",
+    tree = authority$phylogeny,
+    prior = list(A_offdiag = "normal(0, 2)"),
+    nuts_sampler = "nutpie",
+    chains = 1,
+    iter_warmup = 100,
+    iter_sampling = 100,
+    seed = 1
+  )
+  # log_lik is off by default, matching the Stan backend
+  fit <- do.call(coev_fit, fit_args)
+  expect_false(
+    any(grepl("^log_lik", posterior::variables(fit$fit$draws())))
+  )
+  fit <- do.call(coev_fit, c(fit_args, list(log_lik = TRUE)))
+  sd <- fit$stan_data
+  log_lik <- posterior::draws_of(
+    posterior::as_draws_rvars(fit$fit$draws(variables = "log_lik"))$log_lik
+  )
+  expect_equal(dim(log_lik), c(fit$nsamples, sd$N_obs * sd$J))
+  expect_true(all(is.finite(log_lik)))
+  expect_true(all(log_lik <= 0))
+  expect_no_error(suppressWarnings(summary(fit)))
+  skip_if_not_installed("loo")
+  expect_no_error(suppressWarnings(loo::loo(log_lik)))
+})
+
+test_that("JAX log_lik handles normal variables and missing data", {
+  skip_if_not(
+    coevolve:::check_jax_available(),
+    message = "JAX not available - skipping JAX tests"
+  )
+  withr::with_seed(1, {
+    n <- 15
+    tree <- ape::rcoal(n)
+    d <- data.frame(
+      id = tree$tip.label,
+      x = rnorm(n),
+      y = rnorm(n)
+    )
+  })
+  d$x[1:3] <- NA
+  fit <- coev_fit(
+    data = d,
+    variables = list(x = "normal", y = "normal"),
+    id = "id",
+    tree = tree,
+    nuts_sampler = "nutpie",
+    log_lik = TRUE,
+    chains = 1,
+    iter_warmup = 100,
+    iter_sampling = 100,
+    seed = 1
+  )
+  sd <- fit$stan_data
+  log_lik <- posterior::draws_of(
+    posterior::as_draws_rvars(fit$fit$draws(variables = "log_lik"))$log_lik
+  )
+  expect_equal(dim(log_lik), c(fit$nsamples, sd$N_obs * sd$J))
+  expect_true(all(is.finite(log_lik)))
+  # missing cells contribute nothing (log_sum_exp of zeros over one tree)
+  miss_ids <- which(as.vector(sd$miss) == 1)
+  expect_true(all(log_lik[, miss_ids] == 0))
+  expect_true(all(log_lik[, -miss_ids] != 0))
+})
+
+test_that("JAX fit works with prior_only for normal variables", {
+  skip_if_not(
+    coevolve:::check_jax_available(),
+    message = "JAX not available - skipping JAX tests"
+  )
+  withr::with_seed(3, {
+    n <- 8
+    tree <- ape::rcoal(n)
+    d <- data.frame(
+      id = tree$tip.label,
+      x = rnorm(n),
+      y = rnorm(n)
+    )
+  })
+  # terminal_drift has no prior of its own outside the likelihood block, so
+  # prior-only sampling used to be improper and failed to initialise (#118)
+  fit <- coev_fit(
+    data = d,
+    variables = list(x = "normal", y = "normal"),
+    id = "id",
+    tree = tree,
+    nuts_sampler = "nutpie",
+    prior_only = TRUE,
+    chains = 2,
+    iter_warmup = 300,
+    iter_sampling = 300,
+    seed = 1
+  )
+  expect_s3_class(fit, "coevfit")
+  rhat <- posterior::summarise_draws(
+    posterior::subset_draws(fit$fit$draws(), variable = "eta_anc"),
+    "rhat"
+  )$rhat
+  expect_true(all(rhat < 1.05))
+  expect_no_error(suppressWarnings(coev_plot_predictive_check(fit)))
+})
+
 test_that("coev_ancestral_states() works with JAX fit", {
   skip_if_not(
     coevolve:::check_jax_available(),


### PR DESCRIPTION
Closes #118.

Four related fixes to the nutpie/JAX backend (plus one Stan generated-quantities bug found along the way):

- **`coev_plot_predictive_check()` with nutpie** — the JAX backend now computes and returns `yrep` posterior predictions alongside the other model parameters, matching the Stan backend (#118).
- **`log_lik = TRUE` with nutpie** — the argument was previously ignored by the JAX backend, so `loo`/`waic` could not be computed from nutpie fits. The backend now returns pointwise `log_lik`.
- **`prior_only = TRUE` with gaussian variables and no repeated observations** — `terminal_drift` only received its prior inside the likelihood block, leaving it improper when the likelihood was skipped. Sampling failed to initialise with nutpie and was unreliable with Stan. The prior is now also declared when `prior_only = TRUE`.
- **Missing gaussian data in generated quantities** — residuals were constructed from the `-9999` missing-value placeholder, corrupting the conditional `log_lik`/`yrep` densities of the other variables of the same observation. Missing values now fall back to the sampled `residual_z`/`terminal_drift` draws.

New tests in `tests/testthat/test-coev_fit_nutpie.R` cover `yrep` recovery, `log_lik`/`loo` from nutpie fits, `prior_only` initialisation, and missing-data generated quantities.

🤖 Generated with [Claude Code](https://claude.com/claude-code)